### PR TITLE
Padronização com ResidenceController + filtro por tipo e finalidade

### DIFF
--- a/backend/src/main/java/com/moradiasestudantis/gestao_moradias/controller/ResidenceController.java
+++ b/backend/src/main/java/com/moradiasestudantis/gestao_moradias/controller/ResidenceController.java
@@ -1,12 +1,9 @@
 package com.moradiasestudantis.gestao_moradias.controller;
 
-import com.moradiasestudantis.gestao_moradias.dto.ResidenceDto;
-import com.moradiasestudantis.gestao_moradias.model.User;
+import com.moradiasestudantis.gestao_moradias.model.Residence;
 import com.moradiasestudantis.gestao_moradias.service.ResidenceService;
-import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,23 +15,21 @@ public class ResidenceController {
     @Autowired
     private ResidenceService residenceService;
 
-    @PostMapping
-    public ResponseEntity<ResidenceDto> create(@RequestBody @Valid ResidenceDto dto,
-                                               @AuthenticationPrincipal User user) {
-        ResidenceDto createdResidence = residenceService.createResidence(dto, user);
-        return ResponseEntity.status(201).body(createdResidence);
+    @GetMapping("/filter")
+    public ResponseEntity<List<Residence>> filterResidences(
+            @RequestParam(required = false) String tipo,
+            @RequestParam(required = false) String finalidade) {
+        List<Residence> residences = residenceService.filterResidences(tipo, finalidade);
+        return ResponseEntity.ok(residences);
     }
 
     @GetMapping
-    public ResponseEntity<List<ResidenceDto>> getAll(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(residenceService.findResidencesByOwner(user));
+    public ResponseEntity<List<Residence>> getAllResidences() {
+        return ResponseEntity.ok(residenceService.findAll());
     }
 
-    @GetMapping("/search")
-    public ResponseEntity<List<ResidenceDto>> searchResidences(
-            @RequestParam(required = false) String tipo,
-            @RequestParam(required = false) String finalidade) {
-        List<ResidenceDto> residences = residenceService.searchResidences(tipo, finalidade);
-        return ResponseEntity.ok(residences);
+    @PostMapping
+    public ResponseEntity<Residence> createResidence(@RequestBody Residence residence) {
+        return ResponseEntity.ok(residenceService.save(residence));
     }
 }

--- a/backend/src/main/java/com/moradiasestudantis/gestao_moradias/dto/ResidenceDto.java
+++ b/backend/src/main/java/com/moradiasestudantis/gestao_moradias/dto/ResidenceDto.java
@@ -2,29 +2,24 @@ package com.moradiasestudantis.gestao_moradias.dto;
 
 import com.moradiasestudantis.gestao_moradias.model.Residence;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 
 public record ResidenceDto(
         Long id,
 
         @NotBlank(message = "O endereço é obrigatório.")
-        String address,
+        String endereco,
 
-        String description,
+        String tipo,
 
-        @PositiveOrZero(message = "O preço deve ser um valor positivo ou zero.")
-        double price,
-
-        Long ownerId
+        String finalidade
 ) {
-    // Construtor para converter a entidade Residence em DTO
+    
     public ResidenceDto(Residence residence) {
         this(
-                residence.getId(),
-                residence.getAddress(),
-                residence.getDescription(),
-                residence.getPrice(),
-                residence.getOwner().getId()
+            residence.getId(),
+            residence.getEndereco(),
+            residence.getTipo(),
+            residence.getFinalidade()
         );
     }
 }

--- a/backend/src/main/java/com/moradiasestudantis/gestao_moradias/model/Residence.java
+++ b/backend/src/main/java/com/moradiasestudantis/gestao_moradias/model/Residence.java
@@ -1,37 +1,27 @@
 package com.moradiasestudantis.gestao_moradias.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 
 @Entity
-@Table(name = "residences")
 public class Residence {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotBlank(message = "O endereço é obrigatório.")
-    @Column(nullable = false)
-    private String address;
+    private String endereco;
+    private String tipo;
+    private String finalidade;
 
-    private String description;
-
-    @PositiveOrZero
-    private double price;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    @JsonIgnore // Evita loops infinitos na serialização JSON
-    private User owner;
-
-    // Construtores
     public Residence() {
     }
 
-    // Getters e Setters
+    public Residence(String endereco, String tipo, String finalidade) {
+        this.endereco = endereco;
+        this.tipo = tipo;
+        this.finalidade = finalidade;
+    }
+
     public Long getId() {
         return id;
     }
@@ -40,35 +30,27 @@ public class Residence {
         this.id = id;
     }
 
-    public String getAddress() {
-        return address;
+    public String getEndereco() {
+        return endereco;
     }
 
-    public void setAddress(String address) {
-        this.address = address;
+    public void setEndereco(String endereco) {
+        this.endereco = endereco;
     }
 
-    public String getDescription() {
-        return description;
+    public String getTipo() {
+        return tipo;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
     }
 
-    public double getPrice() {
-        return price;
+    public String getFinalidade() {
+        return finalidade;
     }
 
-    public void setPrice(double price) {
-        this.price = price;
-    }
-
-    public User getOwner() {
-        return owner;
-    }
-
-    public void setOwner(User owner) {
-        this.owner = owner;
+    public void setFinalidade(String finalidade) {
+        this.finalidade = finalidade;
     }
 }

--- a/backend/src/main/java/com/moradiasestudantis/gestao_moradias/repository/ResidenceRepository.java
+++ b/backend/src/main/java/com/moradiasestudantis/gestao_moradias/repository/ResidenceRepository.java
@@ -1,18 +1,12 @@
 package com.moradiasestudantis.gestao_moradias.repository;
 
 import com.moradiasestudantis.gestao_moradias.model.Residence;
-import com.moradiasestudantis.gestao_moradias.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 
-public interface ResidenceRepository extends JpaRepository<Residence, Long>, JpaSpecificationExecutor<Residence> {
-
-    /**
-     * Encontra todas as residências associadas a um usuário (proprietário).
-     * @param owner O usuário proprietário.
-     * @return Uma lista de residências.
-     */
-    List<Residence> findByOwner(User owner);
+public interface ResidenceRepository extends JpaRepository<Residence, Long> {
+    List<Residence> findByTipo(String tipo);
+    List<Residence> findByFinalidade(String finalidade);
+    List<Residence> findByTipoAndFinalidade(String tipo, String finalidade);
 }

--- a/backend/src/main/java/com/moradiasestudantis/gestao_moradias/service/ResidenceService.java
+++ b/backend/src/main/java/com/moradiasestudantis/gestao_moradias/service/ResidenceService.java
@@ -1,20 +1,12 @@
 package com.moradiasestudantis.gestao_moradias.service;
 
-import com.moradiasestudantis.gestao_moradias.dto.ResidenceDto;
 import com.moradiasestudantis.gestao_moradias.model.Residence;
-import com.moradiasestudantis.gestao_moradias.model.User;
 import com.moradiasestudantis.gestao_moradias.repository.ResidenceRepository;
-import jakarta.persistence.criteria.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class ResidenceService {
@@ -22,80 +14,23 @@ public class ResidenceService {
     @Autowired
     private ResidenceRepository residenceRepository;
 
-    @Transactional
-    public ResidenceDto createResidence(ResidenceDto dto, User owner) {
-        Residence residence = new Residence();
-        residence.setAddress(dto.address());
-        residence.setDescription(dto.description());
-        residence.setPrice(dto.price());
-        residence.setOwner(owner);
-
-        Residence savedResidence = residenceRepository.save(residence);
-        return new ResidenceDto(savedResidence);
+    public List<Residence> findAll() {
+        return residenceRepository.findAll();
     }
 
-    @Transactional(readOnly = true)
-    public ResidenceDto getResidenceById(Long id) {
-        Residence residence = residenceRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Residência não encontrada"));
-        return new ResidenceDto(residence);
+    public Residence save(Residence residence) {
+        return residenceRepository.save(residence);
     }
 
-    @Transactional(readOnly = true)
-    public List<ResidenceDto> findResidencesByOwner(User owner) {
-        return residenceRepository.findByOwner(owner)
-                .stream()
-                .map(ResidenceDto::new)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public ResidenceDto updateResidence(Long id, ResidenceDto dto, User currentUser) {
-        Residence residence = residenceRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Residência não encontrada"));
-
-        if (!residence.getOwner().getId().equals(currentUser.getId())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado");
+    public List<Residence> filterResidences(String tipo, String finalidade) {
+        if (StringUtils.hasText(tipo) && StringUtils.hasText(finalidade)) {
+            return residenceRepository.findByTipoAndFinalidade(tipo, finalidade);
+        } else if (StringUtils.hasText(tipo)) {
+            return residenceRepository.findByTipo(tipo);
+        } else if (StringUtils.hasText(finalidade)) {
+            return residenceRepository.findByFinalidade(finalidade);
+        } else {
+            return residenceRepository.findAll();
         }
-
-        residence.setAddress(dto.address());
-        residence.setDescription(dto.description());
-        residence.setPrice(dto.price());
-
-        Residence updatedResidence = residenceRepository.save(residence);
-        return new ResidenceDto(updatedResidence);
-    }
-
-    @Transactional
-    public void deleteResidence(Long id, User currentUser) {
-        Residence residence = residenceRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Residência não encontrada"));
-
-        if (!residence.getOwner().getId().equals(currentUser.getId())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado");
-        }
-
-        residenceRepository.delete(residence);
-    }
-
-    @Transactional(readOnly = true)
-    public List<ResidenceDto> searchResidences(String tipo, String finalidade) {
-        Specification<Residence> spec = (root, query, builder) -> {
-            List<Predicate> predicates = new ArrayList<>();
-            // Nota: Os campos 'tipo' e 'finalidade' foram removidos do modelo 'Residence'.
-            // Você precisará adicioná-los de volta ao 'Residence.java' e 'ResidenceDto.java' se quiser usar este filtro.
-            // Exemplo de como seria a lógica:
-            // if (tipo != null && !tipo.isBlank()) {
-            //     predicates.add(builder.equal(root.get("tipo"), tipo));
-            // }
-            // if (finalidade != null && !finalidade.isBlank()) {
-            //     predicates.add(builder.equal(root.get("finalidade"), finalidade));
-            // }
-            return builder.and(predicates.toArray(new Predicate[0]));
-        };
-
-        return residenceRepository.findAll(spec).stream()
-                .map(ResidenceDto::new)
-                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/moradiasestudantis/gestao_moradias/service/StudentService.java
+++ b/backend/src/main/java/com/moradiasestudantis/gestao_moradias/service/StudentService.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;


### PR DESCRIPTION
- Mantida a classe ResidenceController como padrão (em inglês)
- Implementado endpoint /residences/filter no controller
- Criado método filterResidences no ResidenceService com lógica opcional
- Adicionados métodos de consulta no ResidenceRepository
- Atualizada a entidade Residence com campos: endereco, tipo, finalidade
- Corrigido ResidenceDto para refletir nomes em português