### PR TITLE
chore(frontend): configurar apiUrl de produção para backend no Render

### DIFF
--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: '__NG_APP_API_URL__'
+  apiUrl: 'https://gestao-moradias-rp-ajg2.onrender.com'
 };


### PR DESCRIPTION
- Define `src/environments/environment.prod.ts: apiUrl` = https://<SEU-BACKEND>.onrender.com
- Garante que as requisições do Angular em produção apontem para a API publicada
- Passo preparatório para CORS (FRONTEND_URL) no backend
