### PR TITLE
build(frontend): Dockerfile + nginx para SPA e outputPath dist/frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,22 +1,16 @@
-# Estágio de build
-FROM node:20 AS build
+FROM node:20-alpine AS build
 WORKDIR /app
-COPY frontend/package*.json ./
+
+COPY package*.json ./
 RUN npm ci
-COPY frontend/ .
 
-# Argumento para receber a URL da API
-ARG NG_APP_API_URL
+COPY . .
 
-# Substitui o placeholder no arquivo de ambiente pelo valor real da URL
-RUN sed -i "s|__NG_APP_API_URL__|${NG_APP_API_URL}|g" src/environments/environment.prod.ts
-
-# Constrói a aplicação
 RUN npm run build -- --configuration production
 
-# Estágio de produção
 FROM nginx:alpine
-COPY --from=build /app/dist/frontend/browser /usr/share/nginx/html
-# Copia o nginx.conf de dentro da pasta do app que foi copiada
+
+COPY --from=build /app/dist/frontend /usr/share/nginx/html
 COPY --from=build /app/nginx.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 80

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -35,16 +35,8 @@
           "configurations": {
             "production": {
               "budgets": [
-                {
-                  "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
-                },
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
-                }
+                { "type": "initial", "maximumWarning": "500kb", "maximumError": "1mb" },
+                { "type": "anyComponentStyle", "maximumWarning": "2kb", "maximumError": "4kb" }
               ],
               "outputHashing": "all",
               "fileReplacements": [
@@ -65,43 +57,27 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
-            "production": {
-              "buildTarget": "frontend:build:production"
-            },
-            "development": {
-              "buildTarget": "frontend:build:development"
-            }
+            "production": { "buildTarget": "frontend:build:production" },
+            "development": { "buildTarget": "frontend:build:development" }
           },
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
-          "options": {
-            "buildTarget": "frontend:build"
-          }
+          "options": { "buildTarget": "frontend:build" }
         },
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": [ "zone.js", "zone.js/testing" ],
             "tsConfig": "tsconfig.spec.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": [ "src/favicon.ico", "src/assets" ],
+            "styles": [ "src/styles.css" ],
             "scripts": []
           }
         }
       }
     }
   },
-  "cli": {
-    "analytics": false
-  }
+  "cli": { "analytics": false }
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name localhost;
+  server_name _;
 
   root /usr/share/nginx/html;
   index index.html;
@@ -8,4 +8,24 @@ server {
   location / {
     try_files $uri $uri/ /index.html;
   }
+
+  location ~* \.(?:js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
+    expires 30d;
+    add_header Cache-Control "public, max-age=2592000, immutable";
+    access_log off;
+    try_files $uri =404;
+  }
+
+  gzip on;
+  gzip_comp_level 5;
+  gzip_min_length 256;
+  gzip_types
+    text/plain
+    text/css
+    application/json
+    application/javascript
+    application/xml
+    image/svg+xml
+    font/woff2;
+  gzip_vary on;
 }


### PR DESCRIPTION
- Usa outputPath=dist/frontend conforme angular.json
- Copia artefatos para /usr/share/nginx/html
- Adiciona nginx.conf com SPA fallback, cache de estáticos e gzip
- Remove necessidade de ARG/placeholder de API; usa environment.prod.ts
- Preparado para Render: Dockerfile Path=./frontend/Dockerfile, Build Context=./frontend
